### PR TITLE
Remove DC component before correlation measurement

### DIFF
--- a/AnalogMeasurement.py
+++ b/AnalogMeasurement.py
@@ -7,6 +7,9 @@ def freq_from_autocorr(sig, fs):
     """
     Estimate frequency using autocorrelation
     """
+    # Remove DC component
+    sig -= np.mean(sig)
+    
     # Calculate autocorrelation and throw away the negative lags
     corr = numpy.correlate(sig, sig, mode='full')
     corr = corr[len(corr)//2:]

--- a/AnalogMeasurement.py
+++ b/AnalogMeasurement.py
@@ -8,7 +8,7 @@ def freq_from_autocorr(sig, fs):
     Estimate frequency using autocorrelation
     """
     # Remove DC component
-    sig -= np.mean(sig)
+    sig -= numpy.mean(sig)
     
     # Calculate autocorrelation and throw away the negative lags
     corr = numpy.correlate(sig, sig, mode='full')


### PR DESCRIPTION
This makes the measurement work with signals like the following (previously it would show "0 kHz"):

![signal](https://user-images.githubusercontent.com/7355797/139689961-33df2b91-1f1b-4d68-a50f-c519b9fb65b7.PNG)
